### PR TITLE
Set up trusted publishing with semantic-release

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,9 +62,8 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
-      - name: Release
+      - name: Release (Trusted Publishing)
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          NPM_CONFIG_PROVENANCE: true
         run: npx semantic-release

--- a/release.config.js
+++ b/release.config.js
@@ -18,7 +18,7 @@ export default {
       },
     ],
     "@semantic-release/release-notes-generator",
-    "@semantic-release/npm",
+    ["@semantic-release/npm", { npmPublish: true, provenance: true }],
     ["@semantic-release/changelog", { changelogFile: "CHANGELOG.md" }],
     [
       "@semantic-release/git",


### PR DESCRIPTION
- Remove NPM_TOKEN and NODE_AUTH_TOKEN from CI workflow
- Add NPM_CONFIG_PROVENANCE environment variable
- Configure semantic-release npm plugin with provenance enabled
- Keep id-token: write permission for OIDC authentication

This enables npm trusted publishing which eliminates the need for long-lived tokens. The workflow will now authenticate using OIDC and publish with provenance attestations.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated release workflow to implement trusted publishing for enhanced security during package releases.
  * Enabled provenance metadata on published npm packages to provide improved authenticity verification and transparency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->