### PR TITLE
Fix invalid npm token authentication error

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,6 +62,9 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
+      - name: Update npm for Trusted Publishing
+        run: npm install -g npm@latest
+
       - name: Release (Trusted Publishing)
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
- npm Trusted Publishing requires npm CLI v11.5.1 or later
- OIDC tokens handle authentication automatically (no NPM_TOKEN needed)
- Provenance is generated automatically with trusted publishing
- id-token: write permission enables OIDC token generation

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the release process to use the latest npm version during package publishing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->