### PR TITLE
Fix invalid npm token in semantic-release

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,7 +57,6 @@ jobs:
         with:
           node-version: 20
           cache: pnpm
-          registry-url: https://registry.npmjs.org/
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile


### PR DESCRIPTION
When using OIDC trusted publishing, the registry-url parameter in setup-node creates an .npmrc file expecting NODE_AUTH_TOKEN, which conflicts with OIDC authentication flow. Removing this parameter allows npm CLI to automatically detect and use the OIDC environment for authentication.

This resolves the "401 Unauthorized" error during semantic-release's verifyConditions step.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Adjusted release process configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->